### PR TITLE
Sort environment variables to stop file regeneration

### DIFF
--- a/templates/hubot.env.erb
+++ b/templates/hubot.env.erb
@@ -1,3 +1,3 @@
-<% @exports.each do |k,v| -%>
+<% @exports.sort_by{|k,v| k}.each do |k,v| -%>
 export <%= "#{k}=\"#{v}\"" %>
 <% end -%>


### PR DESCRIPTION
Ruby was ordering the environments hash differently on every run, causing the environment to be regenerated and hubot restarted unnecessarily.
