### PR TITLE
Adds alias support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,10 @@
 #   String.  The name this bot should present itself to users as
 #   Default: hubot
 #
+# [*chat_alias*]
+#   String.  A short name the bot will respond to in addition to bot name
+#   Default: /
+#
 # [*build_deps*]
 #   String/Array of Strings.  Any additional packages that should be installed to
 #     support building npm, nodejs, or any npm modules from 'npm install'
@@ -113,6 +117,7 @@ class hubot (
   $root_dir             = $::hubot::params::root_dir,
   $bot_name             = $::hubot::params::bot_name,
   $display_name         = $::hubot::params::display_name,
+  $chat_alias           = $::hubot::params::chat_alias,
   $build_deps           = $::hubot::params::build_deps,
   $env_export           = $::hubot::params::env_export,
   $scripts              = $::hubot::params::scripts,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class hubot::params {
   $root_dir             = '/opt/hubot'
   $bot_name             = 'hubot'
   $display_name         = 'hubot'
+  $chat_alias           = '/'
   $build_deps           = []
   $env_export           = {}
   $scripts              = []

--- a/templates/hubot.init.Ubuntu.erb
+++ b/templates/hubot.init.Ubuntu.erb
@@ -15,9 +15,10 @@ ADAPTER="<%= scope.lookupvar('hubot::adapter') %>"
 LOG_FILE="<%= scope.lookupvar('hubot::log_file_real') %>"
 USER=hubot
 DISPLAY_NAME="<%= scope.lookupvar('hubot::display_name') %>"
+ALIAS="<%= scope.lookupvar('hubot::chat_alias') %>"
 
 HUBOT_BIN="$ROOT_DIR/bin/hubot"
-HUBOT_OPTS="--name ${DISPLAY_NAME} --adapter ${ADAPTER}"
+HUBOT_OPTS="--name ${DISPLAY_NAME} --adapter ${ADAPTER} --alias ${ALIAS}"
 PIDFILE=/var/run/hubot.pid
 
 test -x $HUBOT_BIN || exit 0

--- a/templates/hubot.init.erb
+++ b/templates/hubot.init.erb
@@ -14,11 +14,12 @@ ADAPTER="<%= scope.lookupvar('hubot::adapter') %>"
 LOG_FILE="<%= scope.lookupvar('hubot::log_file_real') %>"
 USER=hubot
 DISPLAY_NAME="<%= scope.lookupvar('hubot::display_name') %>"
+ALIAS="<%= scope.lookupvar('hubot::chat_alias') %>"
 PIDFILE=/var/run/hubot.pid
 
 startHubot() {
   echo -n $"Starting hubot (${DISPLAY_NAME}): "
-  runuser -l $USER -c "source ${ROOT_DIR}/hubot.env && cd ${ROOT_DIR}; ${DAEMON} -a ${ADAPTER} -n \"${DISPLAY_NAME}\"" >> $LOG_FILE 2>&1 &
+  runuser -l $USER -c "source ${ROOT_DIR}/hubot.env && cd ${ROOT_DIR}; ${DAEMON} -a ${ADAPTER} -n \"${DISPLAY_NAME}\" --alias \"${ALIAS}\"" >> $LOG_FILE 2>&1 &
   sleep 3
   PID=$(ps aux | grep node | head -1 | awk '{print $2}')
 


### PR DESCRIPTION
This commit adds the ability for Hubot to respond to messages
directed at it via an alias. This command used to be supported
with the --enabled-slash parameter, and as a result the slash '/'
was fittingly chosen as default.

This value can easily be changed via the parameter 'hubot::chat_alias'
defined in either hiera or at class declaration.

The parameter name `chat_alias` was chosen over `alias`, as the latter
is a Puppet metaparameter.

Examples:

```yaml
---
  hubot::chat_alias: '!'
```

```ruby
  class { 'hubot':
    chat_alias => '!',
  }
```