### PR TITLE
Fixing nodejs declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,13 +148,16 @@ class hubot (
     $service_enable_real = $service_enable
   }
   
-  if $nodejs_manage_repo {
-    class { '::nodejs':
-      manage_repo => $nodejs_manage_repo,
-    }
-  } else {
-    class { '::nodejs': }
+  if $install_nodejs {
+    if $nodejs_manage_repo {
+      class { '::nodejs':
+        manage_repo => $nodejs_manage_repo,
+      }
+    } else {
+      class { '::nodejs': }
+    }  
   }
+
 
   class { '::hubot::install': }
   class { '::hubot::config': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,8 +147,13 @@ class hubot (
     $service_ensure_real = $service_ensure
     $service_enable_real = $service_enable
   }
-  class { '::nodejs':
-    manage_repo => $nodejs_manage_repo,
+  
+  if $nodejs_manage_repo {
+    class { '::nodejs':
+      manage_repo => $nodejs_manage_repo,
+    }
+  } else {
+    class { '::nodejs': }
   }
 
   class { '::hubot::install': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class hubot (
     $service_enable_real = $service_enable
   }
   class { '::nodejs':
-    manage_package_repo => $nodejs_manage_repo,
+    manage_repo => $nodejs_manage_repo,
   }
 
   class { '::hubot::install': }


### PR DESCRIPTION
This commit changes the attribute for Class[nodejs] to `manage_repo`,
which is correct as of `v0.7.1`.

See: https://github.com/puppetlabs/puppetlabs-nodejs/blob/0.7.1/manifests/init.pp#L40