### PR TITLE
Optional hubot.env for VCS users

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,6 +75,18 @@ class hubot::config {
       revision => 'master',
       notify   => Class['hubot::service'],
     }
+    
+    unless empty($::hubot::env_export) {
+      file { "${::hubot::root_dir}/${::hubot::bot_name}/hubot.env":
+        ensure  => 'file',
+        owner   => 'hubot',
+        group   => 'hubot',
+        mode    => '0440',
+        content => template('hubot/hubot.env.erb'),
+        notify  => Class['hubot::service'],
+        require => Vcsrepo["${::hubot::root_dir}/${::hubot::bot_name}"],
+      }
+    }
 
   } else {
     exec { 'Hubot init':

--- a/spec/classes/hubot_spec.rb
+++ b/spec/classes/hubot_spec.rb
@@ -87,6 +87,11 @@ describe 'hubot', :type => :class do
         let(:params) { { :git_source => 'git@git.mycompany.com:hubot.git', :bot_name => 'foobot' } }
         it { should contain_vcsrepo('/opt/hubot/foobot') }
       end
+
+      context 'specify environment variables' do
+        let(:params) { { :env_export => { 'test1' => 'test value 1' } } }
+        it { should contain_file('/opt/hubot/hubot/hubot.env') }
+      end
     end # git_source
 
     context 'no git_source' do


### PR DESCRIPTION
This adds support for optionally specifying hubot::env_export when configuring hubot from a VCS repo.

We use this because our hubot installation requires a number of sensitive env variables (API credentials, etc) - that we don't want to check into a git repository unencrypted.

Using this change, we're able to store these values in hiera, which we can encrypt using hiera-eyaml.