### PR TITLE
Reduce version dependency on puppet-nodejs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "10.04", "12.04", "14.04" ] }
   ],
   "dependencies": [
-    { "name": "puppet/nodejs", "version_requirement": ">=1.1.0 <2.0.0" },
+    { "name": "puppet/nodejs", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
puppet-nodejs >= 1.1.0 has a hard dependency on puppetlabs/apt >= 2.0
which conflicts with many other modules. This reduces the version
constraint to include 1.0.0 which still supports puppetlabs/apt < 2.0.