### PR TITLE
Don't require nodejs class when not managing it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,6 +152,7 @@ class hubot (
   if $install_nodejs {
     class { '::nodejs':
       manage_package_repo => $nodejs_manage_repo,
+      before              => Package['hubot'],
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,6 @@ class hubot::install {
     ensure   => $version,
     require  => [
                   User['hubot'],
-                  Class['nodejs'],
                   Package[$::hubot::build_deps],
     ],
     provider => 'npm',

--- a/spec/classes/hubot_spec.rb
+++ b/spec/classes/hubot_spec.rb
@@ -49,7 +49,7 @@ describe 'hubot', :type => :class do
         :lsbdistcodename => 'precise',
       }
     end
-    it { should contain_class('nodejs').with_manage_package_repo(true) }
+    it { should contain_class('nodejs').with_manage_package_repo(true).that_comes_before('Package[hubot]') }
     it { should contain_file('/etc/init.d/hubot').with_content %r{^\. /lib/lsb/init-functions$} }
   end #install on Ubungu
 


### PR DESCRIPTION
PR #23 made managing nodejs optional.  However, the package resource for
hubot still depended on a class called 'nodejs'.  This resulted in
failure when disabling nodejs management by this module and when a class
called 'nodejs' didn't exist.

This commit puts the resource relationship on the nodejs class
declaration instead of the hubot package resource.  This way, nodejs can
be managed without necessarily using a class called 'nodejs'