### PR TITLE
Updated hubot initialization

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,9 +91,9 @@ class hubot::config {
 
   } else {
     exec { 'Hubot init':
-      command   => "hubot -c ${::hubot::bot_name}",
+      command   => "mkdir -p ${::hubot::bot_name}; cd ${::hubot::bot_name}; yo hubot",
       cwd       => $::hubot::root_dir,
-      path      => '/usr/bin',
+      path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",
       user      => 'hubot',
       group     => 'hubot',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,4 +66,16 @@ class hubot::install {
     require  => Package['hubot'],
     provider => 'npm'
   })
+  
+  ensure_resource('package', 'generator-hubot', {
+    ensure   => present,
+    require  => Package['hubot'],
+    provider => 'npm'
+  })
+
+  ensure_resource('package', 'yo', {
+    ensure   => present,
+    require  => Package['hubot'],
+    provider => 'npm'
+  })
 }

--- a/spec/classes/hubot_spec.rb
+++ b/spec/classes/hubot_spec.rb
@@ -96,7 +96,7 @@ describe 'hubot', :type => :class do
 
     context 'no git_source' do
       it { should contain_exec('Hubot init').with(
-        :command  => 'hubot -c hubot',
+        :command  => 'mkdir -p hubot; cd hubot; yo hubot',
         :cwd      => '/opt/hubot',
         :unless   => 'test -d /opt/hubot/hubot'
       ) }
@@ -120,7 +120,7 @@ describe 'hubot', :type => :class do
       context 'changing bot_name' do
         let(:params) { { :bot_name => 'foobot' } }
         it { should contain_exec('Hubot init').with(
-          :command  => 'hubot -c foobot',
+          :command  => 'mkdir -p foobot; cd foobot; yo hubot',
           :unless   => 'test -d /opt/hubot/foobot'
         ) }
         it { should contain_file('/opt/hubot/foobot/hubot.env')}


### PR DESCRIPTION
This is intended to fix [issue #30](https://github.com/evenup/evenup-hubot/issues/30).  I've altered the installation to make sure yeoman and the hubot generator are installed if they are not already, then modified the config.pp to use the new yeoman method of installation.

The path is longer for more accomodation but in the future this really should be a variable set on operating system.
