### PR TITLE
Setting the service provider for hubot service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,16 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
-  - rvm: 2.1.0
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  allow_failures:
+  - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 notifications:
   email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-   Copyright 2013 EvenUp Inc
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A puppet module that installs and manages a [hubot](http://hubot.github.com) bot
 
 There are two methods of configuring hubot, setting the available parameters (useful for trying it out/simple configs) and storing your config and scripts in git.  Instructions below as well on migrating from parameter config to repo configuration.
 
-Configuring via puppet
+Configuring via Puppet
 ----------------------
 
 This method is great for giving hubot a try to figure out what it's all about and maintaining a simple configuration.  If you want to be able to run hubot with only the shell adapter, no configuration is required other than including this class and then running /opt/hubot/hubot/bin/hubot (that's a lot of hubots) and interact with him on the shell.
@@ -69,7 +69,7 @@ Puppet will now keep hubot up to date based on this git repo and restart the ser
 
 Known Issues:
 -------------
-Only tested on CentOS 6, but should be pretty agnostic.  Feedback/PRs appreciated!
+Only tested on Ubuntu 14.04 but should be flexible.  Feedback/PRs appreciated!
 
 
 License:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,7 +101,7 @@ class hubot::config {
     }
 
     exec { 'Hubot init':
-      command   => "yo hubot --defaults",
+      command   => "yo hubot --defaults --no-insight",
       cwd       => "${::hubot::root_dir}/${::hubot::bot_name}/",
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -100,6 +100,12 @@ class hubot::config {
       logoutput => 'on_failure',
     }
 
+    file { "${::hubot::root_dir}/${::hubot::bot_name}/hubot":
+      ensure  => 'link',
+      target  => '/usr/bin/hubot',
+      require => Exec['Hubot init'],
+    }
+
     file { "${::hubot::root_dir}/${::hubot::bot_name}/debug.sh":
       ensure  => 'file',
       owner   => 'hubot',
@@ -148,7 +154,5 @@ class hubot::config {
       notify  => Class['hubot::service'],
       require => Exec['Hubot init'],
     }
-
   }
-
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,10 +102,17 @@ class hubot::config {
       logoutput => 'on_failure',
     }
 
+    file { "${::hubot::root_dir}/${::hubot::bot_name}/bin":
+      ensure    => 'directory',
+      owner     => 'hubot',
+      group     => 'hubot',
+      require   => Exec['Hubot init'],
+    }
+    
     file { "${::hubot::root_dir}/${::hubot::bot_name}/bin/hubot":
       ensure  => 'link',
       target  => '/usr/bin/hubot',
-      require => Exec['Hubot init'],
+      require => File["${::hubot::root_dir}/${::hubot::bot_name}/bin"],
     }
 
     file { "${::hubot::root_dir}/${::hubot::bot_name}/debug.sh":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -97,10 +97,11 @@ class hubot::config {
       owner     => 'hubot',
       group     => 'hubot',
       mode      => '0750',
+      require   => File["${::hubot::root_dir}"],
     }
-    
+
     exec { 'Hubot init':
-      command   => "yo hubot --owner=\"\" --name=\"${::hubot::bot_name}\" --description=\"A chat bot\" --adapter=shell --defaults",
+      command   => "yo hubot --defaults",
       cwd       => "${::hubot::root_dir}/${::hubot::bot_name}/",
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,7 +23,7 @@ class hubot::config {
   $scripts = $::hubot::scripts
   $external_scripts = $::hubot::external_scripts
   $dependencies = $::hubot::dependencies
-  $hubotversion = $::hubot::hubot_version
+  $hubotversion = $hubot::hubot_version
   
   file { '/etc/init.d/hubot':
     ensure  => 'file',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,8 @@ class hubot::config {
   $scripts = $::hubot::scripts
   $external_scripts = $::hubot::external_scripts
   $dependencies = $::hubot::dependencies
+  $hubotversion = $::hubot::hubot_version
+  
   file { '/etc/init.d/hubot':
     ensure  => 'file',
     owner   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,27 +92,21 @@ class hubot::config {
     }
 
   } else {
+    file { "${::hubot::root_dir}/${::hubot::bot_name}/":
+      ensure    => 'directory',
+      owner     => 'hubot',
+      group     => 'hubot',
+    }
+    
     exec { 'Hubot init':
-      command   => "mkdir -p ${::hubot::bot_name}; cd ${::hubot::bot_name}; yo hubot",
-      cwd       => $::hubot::root_dir,
+      command   => "yo hubot --owner=\"\" --name=\"${::hubot::bot_name}\" --description=\"A chat bot\" --adapter=shell --defaults",
+      cwd       => "${::hubot::root_dir}/${::hubot::bot_name}/",
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",
       user      => 'hubot',
       group     => 'hubot',
       logoutput => 'on_failure',
-    }
-
-    file { "${::hubot::root_dir}/${::hubot::bot_name}/bin":
-      ensure    => 'directory',
-      owner     => 'hubot',
-      group     => 'hubot',
-      require   => Exec['Hubot init'],
-    }
-    
-    file { "${::hubot::root_dir}/${::hubot::bot_name}/bin/hubot":
-      ensure  => 'link',
-      target  => '/usr/bin/hubot',
-      require => File["${::hubot::root_dir}/${::hubot::bot_name}/bin"],
+      require   => File["${::hubot::root_dir}/${::hubot::bot_name}/"],
     }
 
     file { "${::hubot::root_dir}/${::hubot::bot_name}/debug.sh":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,7 +104,6 @@ class hubot::config {
       command   => "yo hubot --defaults --no-insight",
       cwd       => "${::hubot::root_dir}/${::hubot::bot_name}/",
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
-      unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",
       user      => 'hubot',
       group     => 'hubot',
       logoutput => 'on_failure',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,10 +92,11 @@ class hubot::config {
     }
 
   } else {
-    file { "${::hubot::root_dir}/${::hubot::bot_name}/":
+    file { "${::hubot::root_dir}/${::hubot::bot_name}":
       ensure    => 'directory',
       owner     => 'hubot',
       group     => 'hubot',
+      mode      => '0750',
     }
     
     exec { 'Hubot init':
@@ -106,7 +107,7 @@ class hubot::config {
       user      => 'hubot',
       group     => 'hubot',
       logoutput => 'on_failure',
-      require   => File["${::hubot::root_dir}/${::hubot::bot_name}/"],
+      require   => File["${::hubot::root_dir}/${::hubot::bot_name}"],
     }
 
     file { "${::hubot::root_dir}/${::hubot::bot_name}/debug.sh":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@
 #
 # === Authors
 #
+# * Foxx Block <mailto:siliconfoxx@gmail.com>
 # * Justin Lambert <mailto:jlambert@letsevenup.com>
 #
 #
@@ -32,6 +33,18 @@ class hubot::config {
     mode    => '0555',
     content => template("hubot/${hubot::params::hubot_init}"),
     notify  => Class['hubot::service'],
+  }
+  
+  # Check for Upstart
+  if ($os['name'] == "Ubuntu" ) and ($os['release']['major'] in ["10.04", "12.04", "14.04", "14.10"]){
+    file { "hubot upstart":
+      ensure   => 'file',
+      owner    => 'root',
+      group    => 'root',
+      mode     => '0644',
+      path     => "/etc/init/hubot.conf",
+      content  => template("hubot/hubot.upstart.erb"),
+    }
   }
 
   if $::hubot::git_source {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -116,6 +116,7 @@ class hubot::config {
     exec { 'Hubot init':
       command   => "yo hubot --defaults --no-insight",
       cwd       => "${::hubot::root_dir}/${::hubot::bot_name}/",
+      creates   => "${::hubot::root_dir}/${::hubot::bot_name}/bin/hubot",
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       user      => 'hubot',
       group     => 'hubot',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,7 +102,7 @@ class hubot::config {
       logoutput => 'on_failure',
     }
 
-    file { "${::hubot::root_dir}/${::hubot::bot_name}/hubot":
+    file { "${::hubot::root_dir}/${::hubot::bot_name}/bin/hubot":
       ensure  => 'link',
       target  => '/usr/bin/hubot',
       require => Exec['Hubot init'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,9 +91,9 @@ class hubot::config {
 
   } else {
     exec { 'Hubot init':
-      command   => "hubot -c ${::hubot::bot_name}",
+      command   => "mkdir -p ${::hubot::bot_name}; cd ${::hubot::bot_name}; yo hubot",
       cwd       => $::hubot::root_dir,
-      path      => '/usr/bin',
+      path      => '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
       unless    => "test -d ${::hubot::root_dir}/${::hubot::bot_name}",
       user      => 'hubot',
       group     => 'hubot',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,6 +133,8 @@ class hubot (
   $service_enable       = $::hubot::params::service_enable,
   $install_nodejs       = $::hubot::params::install_nodejs,
   $nodejs_manage_repo   = $::hubot::params::nodejs_manage_repo,
+  $init_style           = $::hubot::params::init_style,
+
 ) inherits hubot::params {
 
   if $log_file {
@@ -150,10 +152,25 @@ class hubot (
   }
 
   if $install_nodejs {
-    class { '::nodejs':
-      manage_package_repo => $nodejs_manage_repo,
-      before              => Package['hubot'],
+
+    case $init_style {
+      'upstart': {
+        class { '::nodejs':
+          manage_package_repo => $nodejs_manage_repo,
+          before              => Package['hubot'],
+        }
+      }
+      'systemd': {
+        class { '::nodejs':
+          manage_package_repo       => $nodejs_manage_repo,
+          nodejs_dev_package_ensure => 'present',
+          npm_package_ensure        => 'present',
+          before                    => Package['hubot'],
+        }
+      }
+      default: {}
     }
+
   }
 
   class { '::hubot::install': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class hubot::install {
     require  => Package['hubot'],
     provider => 'npm'
   })
-  
+
   ensure_resource('package', 'generator-hubot', {
     ensure   => present,
     require  => Package['hubot'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,4 +66,16 @@ class hubot::install {
     require  => Package['hubot'],
     provider => 'npm'
   })
+  
+  ensure_resource('package', 'generator-hubot', {
+    ensure   => present,
+    require  => Package['hubot'],
+    provider => 'npm'
+  })
+
+  ensure_resource('package', 'yo', {
+    ensure   => present,
+    require  => Package['hubot'],
+    provider => 'npm'
+  })
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,8 +36,15 @@ class hubot::params {
 
   case $::operatingsystem {
     /Ubuntu|Debian/: {
+      $init_style         = 'upstart'
       $hubot_init         = "hubot.init.${::operatingsystem}.erb"
       $nodejs_manage_repo = true
+    }
+    /RedHat|CentOS/: {
+      if versioncmp($::operatingsystemrelease, '7.0') > 0 {
+        $init_style         = 'systemd'
+        $nodejs_manage_repo = false
+      }
     }
     default: {
       $hubot_init         = 'hubot.init.erb'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,6 +24,7 @@ class hubot::service {
     enable     => $::hubot::service_enable_real,
     hasstatus  => true,
     hasrestart => true,
+    provider   => $::hubot::init_style,
     require    => Class['hubot::config'],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "frozenfoxx-hubot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "frozenfoxx <siliconfoxx@gmail.com>",
   "license": "Apache-2.0",
   "summary": "Installs, configures, and runs a hubot bot by configuring all parameters or as config from a git repo",
@@ -15,7 +15,7 @@
     { "operatingsystem": "Debian", "operatingsystemrelease": [ "7", "8" ] }
   ],
   "dependencies": [
-    { "name": "puppet/nodejs", "version_requirement": ">=1.0.0 <2.0.0" },
+    { "name": "puppet/nodejs", "version_requirement": ">=1.0.0 <2.3.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,17 @@
 {
-  "name": "evenup-hubot",
-  "version": "0.2.0",
-  "author": "Justin Lambert <jlambert@letsevenup.com>",
+  "name": "frozenfoxx-hubot",
+  "version": "1.0.0",
+  "author": "frozenfoxx <siliconfoxx@gmail.com>",
   "license": "Apache-2.0",
   "summary": "Installs, configures, and runs a hubot bot by configuring all parameters or as config from a git repo",
-  "source": "https://github.com/evenup/evenup-hubot",
-  "project_page": "https://github.com/evenup/evenup-hubot",
-  "issues_url": "https://github.com/evenup/evenup-hubot/issues",
-  "tags": ["hubot", "jira"],
+  "source": "https://github.com/frozenfoxx/puppet-hubot",
+  "project_page": "https://github.com/frozenfoxx/puppet-hubot",
+  "issues_url": "https://github.com/frozenfoxx/puppet-hubot/issues",
+  "tags": ["hubot", "chatops"],
   "operatingsystem_support": [
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6", "7" ] },
-    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "10.04", "12.04", "14.04" ] },
+    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04", "16.04" ] },
     { "operatingsystem": "Debian", "operatingsystemrelease": [ "7", "8" ] }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "frozenfoxx-hubot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "frozenfoxx <siliconfoxx@gmail.com>",
   "license": "Apache-2.0",
   "summary": "Installs, configures, and runs a hubot bot by configuring all parameters or as config from a git repo",

--- a/spec/classes/hubot_spec.rb
+++ b/spec/classes/hubot_spec.rb
@@ -96,9 +96,8 @@ describe 'hubot', :type => :class do
 
     context 'no git_source' do
       it { should contain_exec('Hubot init').with(
-        :command  => 'mkdir -p hubot; cd hubot; yo hubot',
-        :cwd      => '/opt/hubot',
-        :unless   => 'test -d /opt/hubot/hubot'
+        :command  => 'yo hubot --defaults --no-insight',
+        :cwd      => '/opt/hubot/hubot',
       ) }
       it { should contain_file('/opt/hubot/hubot/hubot.env')}
       it { should contain_file('/opt/hubot/hubot/hubot-scripts.json')}
@@ -120,8 +119,8 @@ describe 'hubot', :type => :class do
       context 'changing bot_name' do
         let(:params) { { :bot_name => 'foobot' } }
         it { should contain_exec('Hubot init').with(
-          :command  => 'mkdir -p foobot; cd foobot; yo hubot',
-          :unless   => 'test -d /opt/hubot/foobot'
+          :command  => 'yo hubot --defaults --no-insight',
+          :cwd      => '/opt/hubot/foobot',
         ) }
         it { should contain_file('/opt/hubot/foobot/hubot.env')}
         it { should contain_file('/opt/hubot/foobot/hubot-scripts.json')}

--- a/spec/classes/hubot_spec.rb
+++ b/spec/classes/hubot_spec.rb
@@ -96,7 +96,7 @@ describe 'hubot', :type => :class do
 
     context 'no git_source' do
       it { should contain_exec('Hubot init').with(
-        :command  => 'hubot -c hubot',
+        :command  => 'mkdir -p hubot; cd hubot; yo hubot',
         :cwd      => '/opt/hubot',
         :unless   => 'test -d /opt/hubot/hubot'
       ) }
@@ -120,7 +120,7 @@ describe 'hubot', :type => :class do
       context 'changing bot_name' do
         let(:params) { { :bot_name => 'foobot' } }
         it { should contain_exec('Hubot init').with(
-          :command  => 'hubot -c foobot',
+          :command  => 'mkdir -p foobot; cd foobot; yo hubot',
           :unless   => 'test -d /opt/hubot/foobot'
         ) }
         it { should contain_file('/opt/hubot/foobot/hubot.env')}

--- a/templates/hubot.env.erb
+++ b/templates/hubot.env.erb
@@ -1,3 +1,7 @@
 <% @exports.sort_by{|k,v| k}.each do |k,v| -%>
+<% if scope.lookupvar('hubot::init_style') == 'upstart' -%>
 export <%= "#{k}=\"#{v}\"" %>
+<% elsif scope.lookupvar('hubot::init_style') == 'systemd' -%>
+<%= "#{k}=\"#{v}\"" %>
+<% end -%>
 <% end -%>

--- a/templates/hubot.init.Debian.erb
+++ b/templates/hubot.init.Debian.erb
@@ -1,1 +1,0 @@
-hubot.init.Ubuntu.erb

--- a/templates/hubot.init.Debian.erb
+++ b/templates/hubot.init.Debian.erb
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          hubot
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts the hubot service
+# Description:       starts the Hubot bot for the ADAPTER service specified
+### END INIT INFO
+
+ROOT_DIR="<%= scope.lookupvar('hubot::root_dir') %>/<%= scope.lookupvar('hubot::bot_name') %>"
+ADAPTER="<%= scope.lookupvar('hubot::adapter') %>"
+LOG_FILE="<%= scope.lookupvar('hubot::log_file_real') %>"
+USER=hubot
+DISPLAY_NAME="<%= scope.lookupvar('hubot::display_name') %>"
+ALIAS="<%= scope.lookupvar('hubot::chat_alias') %>"
+
+HUBOT_BIN="$ROOT_DIR/bin/hubot"
+HUBOT_OPTS="--name ${DISPLAY_NAME} --adapter ${ADAPTER} --alias ${ALIAS}"
+PIDFILE=/var/run/hubot.pid
+
+test -x $HUBOT_BIN || exit 0
+
+. /lib/lsb/init-functions
+
+# ${ROOT_DIR}/hubot.env contains default settings
+if [ -r ${ROOT_DIR}/hubot.env ]; then
+  . ${ROOT_DIR}/hubot.env
+fi
+
+set -e
+
+start_bot ()
+{
+  start-stop-daemon --start --quiet --chuid $USER --chdir $ROOT_DIR --pidfile $PIDFILE --make-pidfile --background --name hubot --startas $HUBOT_BIN -- $HUBOT_OPTS
+  log_end_msg $?
+}
+
+stop_bot ()
+{
+  start-stop-daemon --stop --quiet --pidfile $PIDFILE
+  STATUS=$?
+  if [ $STATUS == 0 ]; then
+    rm -r $PIDFILE
+  fi
+  log_end_msg $STATUS
+}
+
+status_bot ()
+{
+  if [ -r $PIDFILE ]; then
+    ps -fp `cat /var/run/hubot.pid `
+  else
+    echo "No PIDfile $PIDFILE"
+  fi
+}
+
+case "$1" in
+start)    log_daemon_msg "Starting Hubot - ${DISPLAY_NAME}" "hubot"
+          start_bot
+          ;;
+stop)     log_daemon_msg "Stopping Hubot - ${DISPLAY_NAME}" "hubot"
+          stop_bot
+          ;;
+restart)  log_daemon_msg "Restarting Hubot - ${DISPLAY_NAME}" "hubot"
+          stop_bot
+          start_bot
+          ;;
+status)   log_daemon_msg "Status of Hubot - ${DISPLAY_NAME}" "hubot"
+          status_of_proc -p /var/run/hubot.pid node hubot && exit 0 || exit $?
+          ;;
+esac

--- a/templates/hubot.systemd.erb
+++ b/templates/hubot.systemd.erb
@@ -11,7 +11,7 @@ ExecStart=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/bin/hu
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 RestartSec=10s
-User=root
+User=hubot
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/hubot.systemd.erb
+++ b/templates/hubot.systemd.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=hubot agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/hubot.env
+Restart=on-failure
+WorkingDirectory=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>
+ExecStart=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/bin/hubot --name <%= scope['hubot::display_name'] %> --adapter <%= scope['hubot::adapter'] %> --alias <%= scope['hubot::chat_alias'] %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+RestartSec=10s
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/hubot.upstart.erb
+++ b/templates/hubot.upstart.erb
@@ -1,0 +1,24 @@
+description "Hubot chatbot"
+
+# Subscribe to these upstart events
+# This will make Hubot start on system boot
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+# Path to Hubot installation
+
+# Keep the process alive, limit to 5 restarts in 60s
+respawn
+respawn limit 5 60
+
+script
+  export HUBOT_PATH="<%= scope.lookupvar('hubot::root_dir') %>/<%= scope.lookupvar('hubot::bot_name') %>"
+  export LOGFILE="<%= scope.lookupvar('hubot::log_file_real') %>"
+  export DAEMON="${HUBOT_PATH}/bin/hubot"
+  export ARGS="-a <%= scope.lookupvar('hubot::adapter') %> -n <%= scope.lookupvar('hubot::display_name') %>"
+  export ENV="${HUBOT_PATH}/hubot.env"
+
+  . $ENV
+
+  exec start-stop-daemon --start --chuid ${HUBOT_USER} --chdir $HUBOT_PATH --exec ${DAEMON} -- ${ARGS} >> ${LOGFILE} 2>&1
+end script

--- a/templates/package.json.erb
+++ b/templates/package.json.erb
@@ -1,6 +1,6 @@
 {
   "name": "hosted-hubot",
-  "version": "2.8.3",
+  "version": "<% @hubotversion -%>",
   "private": true,
   "author": "GitHub Inc.",
 

--- a/templates/package.json.erb
+++ b/templates/package.json.erb
@@ -1,6 +1,6 @@
 {
   "name": "hosted-hubot",
-  "version": "<% @hubotversion -%>",
+  "version": "<%= @hubotversion -%>",
   "private": true,
   "author": "GitHub Inc.",
 


### PR DESCRIPTION
I am specifically setting the service provider with `$::hubot::init_style` to avoid not having the service enabled with distributions that have both init daemon and systemd daemon like Debian 8. 
On Debian 8, if you don't specify the provider for the hubot service but set the `init_style` to `systemd`, the hubot service doesn't get enabled automatically:

```
PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
NAME="Debian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=debian
HOME_URL="http://www.debian.org/"
SUPPORT_URL="http://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

 ```
● hubot.service - hubot agent
   Loaded: loaded (/lib/systemd/system/hubot.service; disabled)
   Active: active (running) since Wed 2017-11-15 14:10:12 CST; 44min ago
 Main PID: 31074 (node)
   CGroup: /system.slice/hubot.service
```

By setting the service provider to 'systemd' with '`$::hubot::init_style`', the hubot service does get enabled automatically:

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for admin1-s.dal7sl.bigcommerce.net
Info: Applying configuration version 'e484bfe - Wed Nov 15 11:55:09 2017 -0800'
Notice: /Stage[main]/Hubot::Service/Service[hubot]/enable: enable changed 'false' to 'true'
Notice: Finished catalog run in 49.46 seconds
```

```
● hubot.service - hubot agent
   Loaded: loaded (/lib/systemd/system/hubot.service; enabled)
   Active: active (running) since Wed 2017-11-15 15:06:02 CST; 16min ago
 Main PID: 8364 (node)
   CGroup: /system.slice/hubot.service
           └─8364 node node_modules/.bin/coffee /opt/hubot/hubottest1/node_modules/.bin/hubot --name hubottest1 --na...
```
